### PR TITLE
Fixed build error. Updated README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 *.so
 *.dll
 *.dylib
+*.lib
 
 # Qt-es
 *.qmake.cache

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ How to use
 $ git clone --recursive https://github.com/buzzySmile/qBreakpad.git
 ```
 * Build qBreakpad static library (qBreakpad/handler/)
-* Include "qBreakpad-handler.pri" to your target Qt project
+* Include "qBreakpad.pri" to your target Qt project
 ```c++
-include(libs/qBreakpad/qBreakpad-handler.pri)
+include($$PWD/{PATH_TO_QBREAKPAD}/qBreakpad.pri)
 ```
-* Setup linking with "qBreakpad-handler" library
+* Setup linking with "qBreakpad" library
 ```c++
-QMAKE_LIBDIR += $$OUT_PWD/submodules/breakpad/handler
-LIBS += -lqBreakpad-handler
+QMAKE_LIBDIR += $$PWD/{PATH_TO_QBREAKPAD}/handler
+LIBS += -lqBreakpad
 ```
 * Use ```QBreakpadHandler``` singleton class to enable automatic crash dumps generation on any failure; example:
 ```c++

--- a/demo/program/program.pro
+++ b/demo/program/program.pro
@@ -14,7 +14,7 @@ macx: LIBS += -framework AppKit
 
 # link qBreakpad library
 include($$PWD/../../qBreakpad.pri)
-QMAKE_LIBDIR += $$OUT_PWD/../../handler
+QMAKE_LIBDIR += $$PWD/../../handler
 LIBS += -lqBreakpad
 
 HEADERS += $$PWD/TestThread.h

--- a/handler/handler.pro
+++ b/handler/handler.pro
@@ -9,9 +9,7 @@ QT += core network
 
 OBJECTS_DIR = _build/obj
 MOC_DIR = _build
-win32 {
-    DESTDIR = $$OUT_PWD
-}
+DESTDIR = $$PWD
 
 ### qBreakpad config
 include($$PWD/../config.pri)

--- a/tests/duplicates/duplicates.pro
+++ b/tests/duplicates/duplicates.pro
@@ -13,7 +13,7 @@ CONFIG += c++11
 macx: LIBS += -framework AppKit
 
 include($$PWD/../../qBreakpad.pri)
-QMAKE_LIBDIR += $$OUT_PWD/../../handler
+QMAKE_LIBDIR += $$PWD/../../handler
 LIBS += -lqBreakpad
 
 SOURCES += main.cpp

--- a/tests/duplicates/main.cpp
+++ b/tests/duplicates/main.cpp
@@ -23,14 +23,14 @@
 
 #include <cstdio>
 
-int buggyFunc()
+void buggyFunc()
 {
     delete reinterpret_cast<QString*>(0xFEE1DEAD);
 }
 
-int f3(int);
+void f3(int);
 
-int f1(int i)
+void f1(int i)
 {
     if(i) {
         f3(i-1);
@@ -39,12 +39,12 @@ int f1(int i)
     }
 }
 
-int f2(int i)
+void f2(int i)
 {
     f1( i>0 ? i-1 : i);
 }
 
-int f3(int i)
+void f3(int i)
 {
     f2( i>0 ? i-1 : i );
 }


### PR DESCRIPTION
Fixed build error. Linker was unable to find libqBreakpad.a
Corrected paths and filenames in README.md

To build using Qt>=5.14 #1 should be merged